### PR TITLE
[add] chatbot readingText & sendText

### DIFF
--- a/chatbot/messengerSecretary.py
+++ b/chatbot/messengerSecretary.py
@@ -1,0 +1,40 @@
+import time, win32con, win32api, win32gui
+
+kakao_opentalk_name = 'schedule'
+
+def kakao_sendtext(chatroom_name, text):
+
+    hwndMain = win32gui.FindWindow( None, chatroom_name)
+    hwndEdit = win32gui.FindWindowEx( hwndMain, None, "RichEdit20W", None)
+
+
+    win32api.SendMessage(hwndEdit, win32con.WM_SETTEXT, 0, text)
+    SendReturn(hwndEdit)
+
+def SendReturn(hwnd):
+    win32api.PostMessage(hwnd, win32con.WM_KEYDOWN, win32con.VK_RETURN, 0)
+    time.sleep(0.01)
+    win32api.PostMessage(hwnd, win32con.WM_KEYUP, win32con.VK_RETURN, 0)
+
+def open_chatroom(chatroom_name):
+    hwndkakao = win32gui.FindWindow(None, "카카오톡")
+    hwndkakao_edit1 = win32gui.FindWindowEx( hwndkakao, None, "EVA_ChildWindow", None)
+    hwndkakao_edit2_1 = win32gui.FindWindowEx( hwndkakao_edit1, None, "EVA_Window", None)
+    hwndkakao_edit2_2 = win32gui.FindWindowEx( hwndkakao_edit1, hwndkakao_edit2_1, "EVA_Window", None)
+    hwndkakao_edit3 = win32gui.FindWindowEx( hwndkakao_edit2_2, None, "Edit", None)
+
+    win32api.SendMessage(hwndkakao_edit3, win32con.WM_SETTEXT, 0, chatroom_name)
+    time.sleep(1)
+    SendReturn(hwndkakao_edit3)
+    time.sleep(1)
+
+
+def main():
+    open_chatroom(kakao_opentalk_name)
+
+    text = "test"
+    kakao_sendtext(kakao_opentalk_name, text)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## 제목
 windows10 환경에서 메신저 내용 읽어줄 비서만들기
## 작업내용
 카카오톡 메신저에서 친구목록 & 대화목록으로 들어가서 
해당하는 대화방의 메시지읽기 & 메세지보내기
## 주의사항
hwndkakao_edit2_1 / hwndkakao_edit2_2 의 클래스네임이 pckakao 톡의 구조상
 "EVA_Window"로 중복이기떄문에 23번째 row의 None으로 지정한 FindWindowEx의 시작포인트를
hwndkakao_edit2_1로 value를 지정하면서 edit2_1과 /edit2_2의 범위가 겹치지않게 지정.
 
